### PR TITLE
refactor: use textlint-scripts

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["es2015"],
-  "plugins": ["add-module-exports"]
-}

--- a/package.json
+++ b/package.json
@@ -22,22 +22,17 @@
     "test": "test"
   },
   "scripts": {
-    "build": "babel src --out-dir lib --source-maps",
-    "watch": "babel src --out-dir lib --watch --source-maps",
+    "build": "textlint-scripts build",
+    "watch": "textlint-scripts build --watch",
     "prepublish": "npm run --if-present build",
-    "test": "mocha"
+    "test": "textlint-scripts test"
   },
   "keywords": [
     "textlint",
     "alex"
   ],
   "devDependencies": {
-    "babel-cli": "^6.5.1",
-    "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-preset-es2015": "^6.5.0",
-    "babel-register": "^6.5.2",
-    "mocha": "^2.4.5",
-    "textlint-tester": "^2.0.0"
+    "textlint-scripts": "^1.2.2"
   },
   "dependencies": {
     "alex": "^3.1.0",

--- a/src/textlint-rule-alex.js
+++ b/src/textlint-rule-alex.js
@@ -5,7 +5,7 @@ import alex from "alex";
 const defaultOptions = {
     allow: []
 };
-export default function textlintRuleAlex(context, options = {}) {
+module.exports = function textlintRuleAlex(context, options = {}) {
     const {Syntax, RuleError, report, getSource} = context;
     const helper = new RuleHelper(context);
     const allowWords = options.allow || defaultOptions.allow;


### PR DESCRIPTION
Run [migrate-textlint-scripts](https://github.com/textlint/migrate-textlint-scripts) and migrate to use https://github.com/textlint/migrate-textlint-scripts